### PR TITLE
 Fix low battery percentage warnings

### DIFF
--- a/include/DeviceDriver/EteeDriver.h
+++ b/include/DeviceDriver/EteeDriver.h
@@ -14,6 +14,7 @@
 #include "DeviceDriver/DeviceDriver.h"
 #include "Encode/EteeEncodingManager.h"
 #include "Util/Bones.h"
+#include "Util/RingBuffer.h"
 
 enum class DeviceEventType { HAPTIC_EVENT, STANDBY };
 
@@ -162,6 +163,8 @@ class EteeDeviceDriver : public IDeviceDriver {
 
   std::thread m_inputUpdateThread;
   std::thread m_poseUpdateThread;
+
+  RingBuffer m_batteryRingBuffer;
 
   short m_updateCount;
   std::chrono::milliseconds m_startUpdateCountTime;

--- a/include/Util/RingBuffer.h
+++ b/include/Util/RingBuffer.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <cinttypes>
+
+/// <summary>
+/// A most common element ring buffer that can store up to N elements.
+/// </summary>
+class RingBuffer {
+ public:
+  RingBuffer();
+  RingBuffer(const uint32_t size);
+  ~RingBuffer();
+
+  void Init(const uint32_t size);
+  void Reset();
+  void Push(const uint8_t value);
+  const uint8_t MostCommonElement() const;
+  inline bool IsValid() const {
+    return m_elements != nullptr;
+  }
+
+ private:
+  uint8_t* m_elements;
+  uint32_t* m_counter;
+
+  uint32_t m_size;
+  uint32_t m_occupiedSize;
+  uint32_t m_write;
+};

--- a/src/Util/RingBuffer.cpp
+++ b/src/Util/RingBuffer.cpp
@@ -1,0 +1,100 @@
+#include "Util/RingBuffer.h"
+#include <cstdlib>
+#include <string.h>
+
+constexpr uint8_t RING_BUFFER_VALUE_RANGE = 255;
+
+RingBuffer::RingBuffer() : m_elements(nullptr), m_counter(nullptr), m_size(0), m_write(0), m_occupiedSize(0) {}
+
+RingBuffer::RingBuffer(const uint32_t size) : m_elements(nullptr), m_counter(nullptr), m_size(size), m_write(0), m_occupiedSize(0) {
+  m_elements = static_cast<uint8_t*>(malloc(size * sizeof(uint8_t)));
+  if (m_elements != nullptr) {
+    memset(m_elements, 0xFF, size * sizeof(uint8_t));
+
+    m_counter = static_cast<uint32_t*>(malloc(RING_BUFFER_VALUE_RANGE * sizeof(uint32_t)));
+    if (m_counter != nullptr) {
+      memset(m_counter, 0, RING_BUFFER_VALUE_RANGE * sizeof(uint32_t));
+    }
+  }
+}
+void RingBuffer::Init(const uint32_t size) {
+  m_elements = nullptr;
+  m_counter = nullptr;
+  m_size = size;
+  m_write = 0;
+  m_occupiedSize = 0;
+
+  m_elements = static_cast<uint8_t*>(malloc(size * sizeof(uint8_t)));
+
+  if (m_elements != nullptr) {
+    memset(m_elements, 0xFF, size * sizeof(uint8_t));
+
+    m_counter = static_cast<uint32_t*>(malloc(RING_BUFFER_VALUE_RANGE * sizeof(uint32_t)));
+    if (m_counter != nullptr) {
+      memset(m_counter, 0, RING_BUFFER_VALUE_RANGE * sizeof(uint32_t));
+    }
+  }
+}
+
+RingBuffer::~RingBuffer() {
+  if (m_counter != nullptr) {
+    free(m_counter);
+    m_counter = nullptr;
+  }
+  if (m_elements != nullptr) {
+    free(m_elements);
+    m_elements = nullptr;
+    m_write = -1;
+  }
+}
+
+void RingBuffer::Reset() {
+  if (m_elements != nullptr) {
+    memset(m_elements, 0, m_size * sizeof(uint8_t));
+    if (m_counter != nullptr) {
+      memset(m_counter, 0, RING_BUFFER_VALUE_RANGE * sizeof(uint32_t));
+    }
+  }
+}
+
+void RingBuffer::Push(const uint8_t value) {
+  if (m_elements != nullptr && m_counter != nullptr) {
+    // Increase the occupied size until we fill the buffer
+    if (m_occupiedSize < m_size) {
+      m_occupiedSize++;
+    } else {
+      // buffer is full, handle overwriting
+      uint8_t oldValue = m_elements[m_write];
+      // Decrease last value
+      m_counter[oldValue]--;
+    }
+
+    // Write element, increment counter, update the write pointer
+    m_elements[m_write] = value;
+    m_counter[value]++;
+    m_write = (m_write + 1) % m_size;
+  }
+}
+
+const uint8_t RingBuffer::MostCommonElement() const {
+  if (m_elements != nullptr && m_counter != nullptr) {
+    uint32_t max_count = 0;
+    uint8_t max_value = 0;
+
+    // Go through the counter list and find the largest value
+    for (int i = 0; i < RING_BUFFER_VALUE_RANGE; i++) {
+      if (m_counter[i] > max_count) {
+        max_count = m_counter[i];
+        max_value = i;
+      }
+    }
+
+    return max_value;
+  } else {
+    return 0xFF;  // INVALID VALUE
+  }
+}
+
+// @TODO: You can probably implement this in such a way that we only search the loop whenever we update a value
+//        simply by checking if the new value is larger or smaller than the last value. We would also have to keep track
+//        of how many instances of the most common number are in the list internally and search if it's smaller


### PR DESCRIPTION
# eteeController "Low battery" fix

---

## Motivation

The battery percentage reported by eteeControllers tends to report an incorrect value for a frame or two, which can trigger "Low battery" dialogs in VR for users of VR overlays such as XSOverlay. 

## Problem Analysis

We can notice that overall, the battery level of a controller is accurate with the exception of a few frames where it spikes to an inaccurate or even invalid value. This means that as such, if we can "filter out the noise", where the noise is these outlier frames of inaccurate battery values, we can effectively eliminate the low battery dialogs entirely.

## Solution

To do this, we can use a ring buffer. A ring buffer is a circular buffer which contains a contiguous block of memory values. Once this buffer is full, the read pointer loops back, overwriting old values with new values. I have taken the standard read buffer but removed the read pointer, as it doesn't make sense for this use case. Instead, I implemented a function which determines the most common value in the buffer, and returns it. This allows us to filter out noise.

### Latency

As this system now returns the most common battery value from the buffer, we must be aware that this technically introduces some latency, $64$ frames of latency to be precise, before a new value will be reported to the user in SteamVR. However, at $72\text{ Hz}$, this is still less than a frame, and battery values do not need to be updated every frame to be useful for end users. I deem increasing the latency to just under a second is a worthwhile compromise given it eliminates this battery issue, and is still responsive enough that in practice it'll be accurate enough at any point in time to the true value.

## Implementation notes

I used a buffer of size $128$ so that the buffer is a small one which can easily fit in cache lines, so that this doesn't compromise on speed and latency. My implementation expects 8-bit integers, so I convert from the float to integers and back to float whenever the driver attempts to update the battery percentage in SteamVR. My Ring Buffer implementation may also be invalid if it fails to allocate enough memory (even though this should never happen in practice), so I fallback to the raw value should it be invalid.
