### PR TITLE
Add runtime offsets reload feature

### DIFF
--- a/etee/resources/settings/default.vrsettings
+++ b/etee/resources/settings/default.vrsettings
@@ -2,6 +2,7 @@
     "driver_etee": {
         "left_enabled": true,
         "right_enabled": true,
+        "reload_pose": false,
         "override_serial_port": false,
         "serial_port": 2
     },

--- a/include/ControllerPose.h
+++ b/include/ControllerPose.h
@@ -18,6 +18,7 @@ class ControllerPose {
 
   void SetShadowEteeTracker(short deviceId, bool isRightHand);
   void SetAdaptorIsConnected(bool adaptorConnected, bool isRight);
+  void RediscoverTrackedDevice();
 
  private:
   void DiscoverTrackedDevice();

--- a/include/DeviceDriver/EteeDriver.h
+++ b/include/DeviceDriver/EteeDriver.h
@@ -135,6 +135,8 @@ class EteeDeviceDriver : public IDeviceDriver {
 
   VRControllerState GetControllerState();
 
+  void RediscoverTrackedDevice();
+
  private:
   void StartDevice();
   bool IsRightHand() const;

--- a/include/DeviceProvider.h
+++ b/include/DeviceProvider.h
@@ -36,6 +36,7 @@ class DeviceProvider : public vr::IServerTrackedDeviceProvider {
   void HandleDongleStateUpdate(VRDongleState dongleState);
   void HandleControllerStateUpdate(VRHandedControllerState_t controllerState);
   void HandleDeviceEvent(const vr::ETrackedControllerRole role, const DeviceEvent& event);
+  void HandleDriverSettingsChange();
 
   VRDeviceConfiguration m_leftConfiguration{};
   VRDeviceConfiguration m_rightConfiguration{};

--- a/src/ControllerPose.cpp
+++ b/src/ControllerPose.cpp
@@ -40,6 +40,11 @@ ControllerPose::ControllerPose(VRPoseConfiguration configuration)
       m_eteeTrackerThruRole(false),  // Disable assignment of role through SVR Manage Trackers, use auto-hand-assignment
       m_state(){};
 
+void ControllerPose::RediscoverTrackedDevice() {
+  DriverLog("Rediscovering tracked devices");
+  m_shadowTrackerId = -1;
+}
+
 void ControllerPose::DiscoverTrackedDevice() {
   if (m_eteeTrackerConnected) return;
 

--- a/src/DeviceDriver/EteeDriver.cpp
+++ b/src/DeviceDriver/EteeDriver.cpp
@@ -494,6 +494,10 @@ VRControllerState EteeDeviceDriver::GetControllerState() {
   return m_deviceState;
 }
 
+void EteeDeviceDriver::RediscoverTrackedDevice() {
+  m_controllerPose->RediscoverTrackedDevice();
+}
+
 void EteeDeviceDriver::Deactivate() {
   if (m_isActive.exchange(false)) {
     m_poseUpdateThread.join();


### PR DESCRIPTION
This pull request adds option to reload offsets from config when `driver_etee.reload_pose` setting is set to `true` (reverts back to `false` after reload).

This assumes that some other tool will update the offsets for you via `IVRSettings` interface, which will trigger the `VREvent_AnyDriverSettingsChanged` event. Coincidentally, such tool can be [SteamVR console](http://localhost:27062/console/index.html) (type into the command field at the very bottom of the page, SteamVR must be running):

```
settings tundra_tracker_basic_adaptor_pose_settings.right_x_offset_position 0.1
settings tundra_tracker_basic_adaptor_pose_settings.right_x_offset_rotation 90
settings driver_etee.reload_pose true
```