### PR TITLE
Move settings_helper to local scope

### DIFF
--- a/src/ControllerPose.cpp
+++ b/src/ControllerPose.cpp
@@ -30,8 +30,6 @@ const char* c_viveTrackerManufacturer = "HTC";
 const char* c_tundraTrackerManufacturer = "Tundra Labs";
 
 const char* c_driverOffsetToggle = "etee_controller_offset";
-vr::CVRSettingHelper settings_helper(vr::VRSettings());
-const std::string poseOffset = settings_helper.GetString(c_driverOffsetToggle, "tracker_pose");
 
 ControllerPose::ControllerPose(VRPoseConfiguration configuration)
     : m_configuration(configuration),
@@ -42,6 +40,9 @@ ControllerPose::ControllerPose(VRPoseConfiguration configuration)
 
 void ControllerPose::DiscoverTrackedDevice() {
   if (m_eteeTrackerConnected) return;
+
+  vr::CVRSettingHelper settings_helper(vr::VRSettings());
+  const std::string poseOffset = settings_helper.GetString(c_driverOffsetToggle, "tracker_pose");
 
   for (int32_t i = 1; i < vr::k_unMaxTrackedDeviceCount; i++) {
     vr::PropertyContainerHandle_t container = vr::VRProperties()->TrackedDeviceToPropertyContainer(i);


### PR DESCRIPTION
Recent change broke driver DLL with some cryptic runtime errors when SteamVR tries to load it. Most likely it has something to do with initialization order of the OpenVR driver/settings. This PR fixes the issue.